### PR TITLE
Move font loading action into dropdown menu

### DIFF
--- a/src/components/designer-controls/FontFamilyPicker.svelte
+++ b/src/components/designer-controls/FontFamilyPicker.svelte
@@ -55,43 +55,42 @@
     oninput={(e) => valueUpdated(e.currentTarget.value)} />
 
   <!-- svelte-ignore a11y_consider_explicit_label -->
-  {#if $fontCache.length > 0 || $userFonts.length > 0}
-    <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown"></button>
+  <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown"></button>
 
-    <div class="dropdown-menu">
-      {#if $userFonts.length > 0}
-        <h6 class="dropdown-header">{$tr("params.text.user_fonts")}</h6>
-        {#each $userFonts as font (font.family)}
-          <button
-            class="dropdown-item"
-            style="font-family: {font.family}"
-            type="button"
-            onclick={() => valueUpdated(font.family)}>
-            {font.family}
-          </button>
-        {/each}
-      {/if}
+  <div class="dropdown-menu">
+    {#if $userFonts.length > 0}
+      <h6 class="dropdown-header">{$tr("params.text.user_fonts")}</h6>
+      {#each $userFonts as font (font.family)}
+        <button
+          class="dropdown-item"
+          style="font-family: {font.family}"
+          type="button"
+          onclick={() => valueUpdated(font.family)}>
+          {font.family}
+        </button>
+      {/each}
+    {/if}
 
-      {#if $fontCache.length > 0}
-        <h6 class="dropdown-header">{$tr("params.text.system_fonts")}</h6>
-        {#each $fontCache as family (family)}
-          <button
-            class="dropdown-item"
-            style="font-family: {family}"
-            type="button"
-            onclick={() => valueUpdated(family)}>
-            {family}
-          </button>
-        {/each}
-      {/if}
-    </div>
-  {/if}
+    {#if $fontCache.length > 0}
+      <h6 class="dropdown-header">{$tr("params.text.system_fonts")}</h6>
+      {#each $fontCache as family (family)}
+        <button
+          class="dropdown-item"
+          style="font-family: {family}"
+          type="button"
+          onclick={() => valueUpdated(family)}>
+          {family}
+        </button>
+      {/each}
+    {/if}
 
-  {#if fontQuerySupported}
-    <button class="btn btn-outline-secondary" onclick={getSystemFonts} title={$tr("params.text.fetch_fonts")}>
-      <MdIcon icon="refresh" />
-    </button>
-  {/if}
+    {#if fontQuerySupported}
+      <div class="dropdown-divider"></div>
+      <button class="dropdown-item load-system-fonts" type="button" onclick={getSystemFonts}>
+        <MdIcon icon="refresh" /> {$tr("params.text.fetch_fonts")}
+      </button>
+    {/if}
+  </div>
 
   <FontsMenu />
 </div>
@@ -108,5 +107,9 @@
   .dropdown-menu {
     max-height: 240px;
     overflow-y: auto;
+  }
+
+  .load-system-fonts {
+    color: var(--bs-primary);
   }
 </style>

--- a/src/locale/dicts/en.json
+++ b/src/locale/dicts/en.json
@@ -114,7 +114,7 @@
     "params.text.bold": "Bold",
     "params.text.edit.title": "Editing text",
     "params.text.edit": "Edit in popup",
-    "params.text.fetch_fonts": "Fetch fonts",
+    "params.text.fetch_fonts": "Load system fonts",
     "params.text.font_family": "Font family",
     "params.text.user_fonts": "User fonts",
     "params.text.system_fonts": "System fonts",


### PR DESCRIPTION
The "Load system fonts" button was sitting outside the dropdown as a separate icon button, which made it easy to miss. This moves it inside the font dropdown menu as the last item, separated by a divider. Now users open one dropdown and see their fonts plus the option to load system fonts in one place.

Also makes the dropdown toggle always visible so first-time users can discover the load action without needing cached fonts first.

## Screenshot

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/b177321d-d7ba-47d1-b96a-8efc6f941fae" />
