### PR TITLE
Added canvas panning and touch support for mobile zooming/panning

### DIFF
--- a/src/components/LabelDesigner.svelte
+++ b/src/components/LabelDesigner.svelte
@@ -474,7 +474,7 @@
 
 <div class="image-editor">
   <div class="row mb-3">
-    <div class="col d-flex {windowWidth === 0 || labelProps.size.width < windowWidth ? 'justify-content-center' : ''}">
+    <div class="col d-flex justify-content-center">
       <div class="canvas-wrapper print-start-{labelProps.printDirection}">
         <canvas bind:this={htmlCanvas}></canvas>
       </div>
@@ -606,6 +606,9 @@
   .canvas-wrapper {
     border: 1px solid rgba(0, 0, 0, 0.4);
     background-color: rgba(60, 55, 63, 0.5);
+    max-width: 100%;
+    max-height: 70vh;
+    overflow: auto;
   }
   .canvas-wrapper.print-start-left {
     border-left: 2px solid #ff4646;
@@ -615,5 +618,6 @@
   }
   .canvas-wrapper canvas {
     image-rendering: pixelated;
+    display: block;
   }
 </style>

--- a/src/components/MainPage.svelte
+++ b/src/components/MainPage.svelte
@@ -17,52 +17,54 @@
   let debugStuffShow = $state<boolean>(false);
 </script>
 
-<div class="container my-2">
-  <div class="row align-items-center mb-3">
-    <div class="col">
-      <h1 class="title">
-        <span class="niim">Niim</span><span class="blue">Blue{isStandalone ? "s" : ""}</span>
-      </h1>
+<div class="page-wrapper d-flex flex-column min-vh-100">
+  <div class="container my-2 flex-grow-1">
+    <div class="row align-items-center mb-3">
+      <div class="col">
+        <h1 class="title">
+          <span class="niim">Niim</span><span class="blue">Blue{isStandalone ? "s" : ""}</span>
+        </h1>
+      </div>
+      <div class="col-md-3">
+        <PrinterConnector />
+      </div>
     </div>
-    <div class="col-md-3">
-      <PrinterConnector />
+    <div class="row">
+      <div class="col">
+        <BrowserWarning />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col">
-      <BrowserWarning />
+
+    <div class="row">
+      <div class="col">
+        <LabelDesigner />
+      </div>
     </div>
   </div>
 
-  <div class="row">
-    <div class="col">
-      <LabelDesigner />
+  <div class="footer text-end text-secondary p-3">
+    <div>
+      <select class="form-select form-select-sm text-secondary d-inline-block w-auto" bind:value={$locale}>
+        {#each Object.entries(locales) as [key, name] (key)}
+          <option value={key}>{name}</option>
+        {/each}
+      </select>
     </div>
-  </div>
-</div>
-
-<div class="footer text-end text-secondary p-3">
-  <div>
-    <select class="form-select form-select-sm text-secondary d-inline-block w-auto" bind:value={$locale}>
-      {#each Object.entries(locales) as [key, name] (key)}
-        <option value={key}>{name}</option>
-      {/each}
-    </select>
-  </div>
-  <div>
-    {#if appCommit}
-      <a class="text-secondary" href="https://github.com/MultiMote/niimblue/commit/{appCommit}">
-        {appCommit.slice(0, 6)}
-      </a>
-    {/if}
-    {$tr("main.built")}
-    {buildDate}
-  </div>
-  <div>
-    <a class="text-secondary" href="https://github.com/MultiMote/niimblue">{$tr("main.code")}</a>
-    <button class="text-secondary btn btn-link p-0" onclick={() => debugStuffShow = true}>
-      <MdIcon icon="bug_report" />
-    </button>
+    <div>
+      {#if appCommit}
+        <a class="text-secondary" href="https://github.com/MultiMote/niimblue/commit/{appCommit}">
+          {appCommit.slice(0, 6)}
+        </a>
+      {/if}
+      {$tr("main.built")}
+      {buildDate}
+    </div>
+    <div>
+      <a class="text-secondary" href="https://github.com/MultiMote/niimblue">{$tr("main.code")}</a>
+      <button class="text-secondary btn btn-link p-0" onclick={() => debugStuffShow = true}>
+        <MdIcon icon="bug_report" />
+      </button>
+    </div>
   </div>
 </div>
 
@@ -80,16 +82,5 @@
   }
 
   .footer {
-    position: absolute;
-    bottom: 0;
-    right: 0;
-    z-index: -1;
-  }
-
-  @media only screen and (max-device-width: 540px) {
-    .footer {
-      position: relative !important;
-      z-index: 0 !important;
-    }
   }
 </style>

--- a/src/fabric-object/custom_canvas.ts
+++ b/src/fabric-object/custom_canvas.ts
@@ -67,9 +67,7 @@ export class CustomCanvas extends fabric.Canvas {
         "touchstart",
         (e: TouchEvent) => {
           if (e.touches.length === 2) {
-
             this.selection = false;
-
             this.discardActiveObject();
 
             const touch1 = e.touches[0];
@@ -108,9 +106,11 @@ export class CustomCanvas extends fabric.Canvas {
             );
 
             if (initialPinchDistance > 0) {
-              const newZoom = (currentPinchDistance / initialPinchDistance) * initialZoom;
-              if (isFinite(newZoom) && newZoom > 0) {
-                this.virtualZoom(newZoom);
+              const newZoom = currentPinchDistance / initialPinchDistance * initialZoom;
+              if (Math.abs(newZoom - this.virtualZoomRatio) > 0.02) {
+                if (isFinite(newZoom) && newZoom > 0) {
+                  this.virtualZoom(newZoom);
+                }
               }
             }
 
@@ -134,11 +134,16 @@ export class CustomCanvas extends fabric.Canvas {
         { passive: false },
     );
 
-    const stopPanning = () => {
-      this.selection = true;
+    const stopTouch = (e: TouchEvent) => {
+      if (e.touches.length === 0) {
+        // If not adding this delay, it could happen that objects are selected after zooming/panning
+        setTimeout(() => {
+          this.selection = true;
+        }, 10);
+      }
     };
-    container.addEventListener("touchend", stopPanning);
-    container.addEventListener("touchcancel", stopPanning);
+    container.addEventListener("touchend", stopTouch);
+    container.addEventListener("touchcancel", stopTouch);
   }
 
   public virtualZoom(newZoom: number) {

--- a/src/fabric-object/custom_canvas.ts
+++ b/src/fabric-object/custom_canvas.ts
@@ -36,22 +36,109 @@ export class CustomCanvas extends fabric.Canvas {
     options?: fabric.TOptions<fabric.CanvasOptions>,
   ) {
     super(el, options);
-    this.setupZoom();
+    this.setupZoomAndPan();
     this.preserveObjectStacking = true;
   }
 
-  private setupZoom() {
+  private setupZoomAndPan() {
     this.on("mouse:wheel", (opt) => {
       const event = opt.e as WheelEvent;
-      event.preventDefault();
 
-      const delta = event.deltaY;
-      if (delta > 0) {
-        this.virtualZoomOut();
-      } else {
-        this.virtualZoomIn();
+      if (event.ctrlKey) {
+        event.preventDefault();
+
+        const delta = event.deltaY;
+        if (delta > 0) {
+          this.virtualZoomOut();
+        } else {
+          this.virtualZoomIn();
+        }
       }
     });
+
+    const container = this.getElement().parentElement;
+    if (!container) return;
+
+    let initialPinchDistance = 0;
+    let initialZoom = 1;
+    let lastMidPoint = { x: 0, y: 0 };
+
+    container.addEventListener(
+        "touchstart",
+        (e: TouchEvent) => {
+          if (e.touches.length === 2) {
+
+            this.selection = false;
+
+            this.discardActiveObject();
+
+            const touch1 = e.touches[0];
+            const touch2 = e.touches[1];
+
+            initialPinchDistance = Math.hypot(
+                touch1.clientX - touch2.clientX,
+                touch1.clientY - touch2.clientY,
+            );
+            initialZoom = this.getVirtualZoom();
+
+            lastMidPoint = {
+              x: (touch1.clientX + touch2.clientX) / 2,
+              y: (touch1.clientY + touch2.clientY) / 2,
+            };
+          } else if (e.touches.length === 1) {
+
+          }
+        },
+        { passive: false },
+    );
+
+    container.addEventListener(
+        "touchmove",
+        (e: TouchEvent) => {
+          if (e.touches.length === 2) {
+            e.preventDefault();
+
+            const touch1 = e.touches[0];
+            const touch2 = e.touches[1];
+
+            // Zoom
+            const currentPinchDistance = Math.hypot(
+                touch1.clientX - touch2.clientX,
+                touch1.clientY - touch2.clientY,
+            );
+
+            if (initialPinchDistance > 0) {
+              const newZoom = (currentPinchDistance / initialPinchDistance) * initialZoom;
+              if (isFinite(newZoom) && newZoom > 0) {
+                this.virtualZoom(newZoom);
+              }
+            }
+
+            // Pan
+            const currentMidPoint = {
+              x: (touch1.clientX + touch2.clientX) / 2,
+              y: (touch1.clientY + touch2.clientY) / 2,
+            };
+
+            const dx = currentMidPoint.x - lastMidPoint.x;
+            const dy = currentMidPoint.y - lastMidPoint.y;
+
+            const wrapper = this.getElement().closest(".canvas-wrapper");
+            if (wrapper) {
+              wrapper.scrollLeft -= dx;
+              wrapper.scrollTop -= dy;
+            }
+            lastMidPoint = currentMidPoint;
+          }
+        },
+        { passive: false },
+    );
+
+    const stopPanning = () => {
+      this.selection = true;
+    };
+    container.addEventListener("touchend", stopPanning);
+    container.addEventListener("touchcancel", stopPanning);
   }
 
   public virtualZoom(newZoom: number) {


### PR DESCRIPTION
* Add panning/dragging of canvas
* Touch gestures for mobiles
* Change scroll wheel to pan
* Zooming by mouse is now with `Ctrl` and scrolling
* Always align canvas in the center
* Prohibit content overlapping footer

Changed the footer, because when zooming in the canvas it would often overlap with the footer and wouldn't look nice.
I also would liked to have panning with mouse middle click, but could't get that working.