### PR TITLE
Refactor printer integration behind an adapter

### DIFF
--- a/src/components/PrintPreview.svelte
+++ b/src/components/PrintPreview.svelte
@@ -5,16 +5,15 @@
   import * as effects from "$/utils/post_process";
   import {
     type EncodedImage,
-    ImageEncoder,
     LabelType,
     printTaskNames,
     type PrintProgressEvent,
     type PrintTaskName,
-    AbstractPrintTask,
     Utils,
     PrintOptions,
     PageColorType
   } from "@mmote/niimbluelib";
+  import type { PrinterPrintTask } from "$/printers";
   import type { LabelProps, PostProcessType, FabricJson, PreviewProps, PreviewPropsOffset } from "$/types";
   import ParamLockButton from "$/components/basic/ParamLockButton.svelte";
   import { tr, type TranslationKey } from "$/utils/i18n";
@@ -64,7 +63,7 @@
   let pagesTotal = $state<number>(1);
   let offset = $state<PreviewPropsOffset>({ x: 0, y: 0, offsetType: "inner" });
   let offsetWarning = $state<string>("");
-  let currentPrintTask: AbstractPrintTask | undefined;
+  let currentPrintTask: PrinterPrintTask | undefined;
 
   let savedProps = $state<PreviewProps>({});
 
@@ -88,7 +87,7 @@
         await currentPrintTask.printEnd();
       } else {
         console.warn("Print task undefined, falling back to PrintEnd command");
-        await $printerClient.abstraction.printEnd();
+        await $printerClient.printEnd();
       }
 
       refreshRfidInfo();
@@ -140,7 +139,7 @@
         }
       }
 
-      currentPrintTask = $printerClient.abstraction.newPrintTask(printTaskName, opts);
+      currentPrintTask = $printerClient.newPrintTask(printTaskName, opts);
 
       page = curPage;
       console.log("Printing page", page);
@@ -148,7 +147,11 @@
       await generatePreviewData(page);
 
       try {
-        const encoded: EncodedImage = ImageEncoder.encodeCanvas(previewCanvas, opts.pageColor!, labelProps.printDirection);
+        const encoded: EncodedImage = $printerClient.encodeCanvas(
+          previewCanvas,
+          opts.pageColor!,
+          labelProps.printDirection,
+        );
         await currentPrintTask.printInit();
         await currentPrintTask.printPage(encoded, quantity);
       } catch (e) {

--- a/src/components/PrinterConnector.svelte
+++ b/src/components/PrinterConnector.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NiimbotCapacitorBleClient, SoundSettingsItemType, Utils, type AvailableTransports } from "@mmote/niimbluelib";
+  import { Utils, type AvailableTransports } from "@mmote/niimbluelib";
   import {
     printerClient,
     connectedPrinterName,
@@ -31,7 +31,7 @@
     connectionState.set("connecting");
 
     try {
-      if ($printerClient instanceof NiimbotCapacitorBleClient && $automation?.autoConnectDeviceId !== undefined) {
+      if ($printerClient.capabilities.deviceIdConnection && $automation?.autoConnectDeviceId !== undefined) {
         await $printerClient.connect({ deviceId: $automation.autoConnectDeviceId });
       } else {
         await $printerClient.connect();
@@ -55,13 +55,11 @@
   };
 
   const soundOn = async () => {
-    await $printerClient.abstraction.setSoundEnabled(SoundSettingsItemType.BluetoothConnectionSound, true);
-    await $printerClient.abstraction.setSoundEnabled(SoundSettingsItemType.PowerSound, true);
+    await $printerClient.setSoundEnabled(true);
   };
 
   const soundOff = async () => {
-    await $printerClient.abstraction.setSoundEnabled(SoundSettingsItemType.BluetoothConnectionSound, false);
-    await $printerClient.abstraction.setSoundEnabled(SoundSettingsItemType.PowerSound, false);
+    await $printerClient.setSoundEnabled(false);
   };
 
   const fetchInfo = async () => {
@@ -69,7 +67,7 @@
   };
 
   const reset = async () => {
-    await $printerClient.abstraction.printerReset();
+    await $printerClient.reset();
   };
 
   const switchConnectionType = (c: ConnectionType) => {
@@ -208,7 +206,9 @@
         </div>
       {/if}
 
-      <FirmwareUpdater />
+      {#if $printerClient.capabilities.firmwareUpdate}
+        <FirmwareUpdater />
+      {/if}
 
       <button
         class="btn btn-sm btn-outline-secondary d-block w-100 mt-1"
@@ -222,10 +222,14 @@
         <div class="d-flex flex-wrap gap-1 mt-1">
           <button class="btn btn-sm btn-primary" onclick={startHeartbeat}>Heartbeat on</button>
           <button class="btn btn-sm btn-primary" onclick={stopHeartbeat}>Heartbeat off</button>
-          <button class="btn btn-sm btn-primary" onclick={soundOn}>Sound on</button>
-          <button class="btn btn-sm btn-primary" onclick={soundOff}>Sound off</button>
+          {#if $printerClient.capabilities.soundSettings}
+            <button class="btn btn-sm btn-primary" onclick={soundOn}>Sound on</button>
+            <button class="btn btn-sm btn-primary" onclick={soundOff}>Sound off</button>
+          {/if}
           <button class="btn btn-sm btn-primary" onclick={fetchInfo}>Fetch info again</button>
-          <button class="btn btn-sm btn-primary" onclick={reset}>Reset</button>
+          {#if $printerClient.capabilities.printerReset}
+            <button class="btn btn-sm btn-primary" onclick={reset}>Reset</button>
+          {/if}
         </div>
       </div>
     </div>

--- a/src/components/basic/FirmwareUpdater.svelte
+++ b/src/components/basic/FirmwareUpdater.svelte
@@ -46,7 +46,7 @@
     try {
       $printerClient.on("firmwareprogress", listener);
       fwProgress = "...";
-      await $printerClient.abstraction.firmwareUpgrade(fwData, fwVersion);
+      await $printerClient.firmwareUpgrade(fwData, fwVersion);
       $printerClient.off("firmwareprogress", listener);
       await $printerClient.disconnect();
 

--- a/src/printers/index.ts
+++ b/src/printers/index.ts
@@ -1,0 +1,21 @@
+import type { ConnectionType } from "$/types";
+import type { PrinterClient } from "$/printers/types";
+import { NiimbotPrinterClient } from "$/printers/niimbot_adapter";
+
+export const instantiatePrinterClient = (connectionType: ConnectionType): PrinterClient => {
+  return new NiimbotPrinterClient(connectionType);
+};
+
+export type {
+  PrinterCapabilities,
+  PrinterClient,
+  PrinterEventListener,
+  PrinterEventMap,
+  PrinterEventName,
+  PrinterHeartbeatData,
+  PrinterInfo,
+  PrinterMetadata,
+  PrinterPacket,
+  PrinterPrintTask,
+  PrinterRfidInfo,
+} from "$/printers/types";

--- a/src/printers/niimbot_adapter.ts
+++ b/src/printers/niimbot_adapter.ts
@@ -1,0 +1,128 @@
+import {
+  ImageEncoder,
+  NiimbotCapacitorBleClient,
+  RequestCommandId,
+  ResponseCommandId,
+  SoundSettingsItemType,
+  instantiateClient,
+  type NiimbotAbstractClient,
+  type PageColorType,
+  type PrintDirection,
+  type PrintOptions,
+  type PrintTaskName,
+} from "@mmote/niimbluelib";
+import type { ConnectionType } from "$/types";
+import type {
+  PrinterClient,
+  PrinterEventListener,
+  PrinterEventName,
+  PrinterMetadata,
+  PrinterPrintTask,
+  PrinterRfidInfo,
+} from "$/printers/types";
+
+export class NiimbotPrinterClient implements PrinterClient {
+  public readonly family = "niimbot" as const;
+  public readonly capabilities;
+  private readonly client: NiimbotAbstractClient;
+
+  public constructor(public readonly connectionType: ConnectionType) {
+    this.client = instantiateClient(connectionType);
+    this.capabilities = {
+      deviceIdConnection: this.client instanceof NiimbotCapacitorBleClient,
+      firmwareUpdate: true,
+      printerReset: true,
+      rfid: true,
+      soundSettings: true,
+      printTaskSelection: true,
+      paperTypeSelection: true,
+    };
+  }
+
+  public async connect(options?: { deviceId?: string }): Promise<void> {
+    if (this.client instanceof NiimbotCapacitorBleClient && options?.deviceId !== undefined) {
+      await this.client.connect({ deviceId: options.deviceId });
+    } else {
+      await this.client.connect();
+    }
+  }
+
+  public async disconnect(): Promise<void> {
+    await this.client.disconnect();
+  }
+
+  public isConnected(): boolean {
+    return this.client.isConnected();
+  }
+
+  public async fetchPrinterInfo(): Promise<void> {
+    await this.client.fetchPrinterInfo();
+  }
+
+  public getModelMetadata(): PrinterMetadata | undefined {
+    return this.client.getModelMetadata();
+  }
+
+  public getPrintTaskType(): PrintTaskName | undefined {
+    return this.client.getPrintTaskType();
+  }
+
+  public encodeCanvas(canvas: HTMLCanvasElement, pageColor: PageColorType, printDirection: PrintDirection) {
+    return ImageEncoder.encodeCanvas(canvas, pageColor, printDirection);
+  }
+
+  public newPrintTask(name: PrintTaskName, options: Partial<PrintOptions>): PrinterPrintTask {
+    return this.client.abstraction.newPrintTask(name, options);
+  }
+
+  public printEnd(): Promise<boolean> {
+    return this.client.abstraction.printEnd();
+  }
+
+  public async getRfidInfo(): Promise<PrinterRfidInfo> {
+    return this.client.abstraction.rfidInfo();
+  }
+
+  public async getRibbonRfidInfo(): Promise<PrinterRfidInfo> {
+    return this.client.abstraction.rfidInfo2();
+  }
+
+  public async setSoundEnabled(enabled: boolean): Promise<void> {
+    await this.client.abstraction.setSoundEnabled(SoundSettingsItemType.BluetoothConnectionSound, enabled);
+    await this.client.abstraction.setSoundEnabled(SoundSettingsItemType.PowerSound, enabled);
+  }
+
+  public async reset(): Promise<void> {
+    await this.client.abstraction.printerReset();
+  }
+
+  public async firmwareUpgrade(data: Uint8Array, version: string): Promise<void> {
+    await this.client.abstraction.firmwareUpgrade(data, version);
+  }
+
+  public setPacketInterval(milliseconds: number): void {
+    this.client.setPacketInterval(milliseconds);
+  }
+
+  public startHeartbeat(): void {
+    this.client.startHeartbeat();
+  }
+
+  public stopHeartbeat(): void {
+    this.client.stopHeartbeat();
+  }
+
+  public getPacketCommandName(direction: "request" | "response", command: number): string | undefined {
+    return direction === "request" ? RequestCommandId[command] : ResponseCommandId[command];
+  }
+
+  public on<K extends PrinterEventName>(event: K, listener: PrinterEventListener<K>): this {
+    this.client.on(event, listener as never);
+    return this;
+  }
+
+  public off<K extends PrinterEventName>(event: K, listener: PrinterEventListener<K>): this {
+    this.client.off(event, listener as never);
+    return this;
+  }
+}

--- a/src/printers/types.ts
+++ b/src/printers/types.ts
@@ -1,0 +1,108 @@
+import type {
+  EncodedImage,
+  FirmwareProgressEvent,
+  LabelType,
+  PageColorType,
+  PrintDirection,
+  PrintOptions,
+  PrintProgressEvent,
+  PrintTaskName,
+} from "@mmote/niimbluelib";
+import type { ConnectionType } from "$/types";
+
+export type PrinterFamily = string;
+
+export type PrinterCapabilities = {
+  deviceIdConnection: boolean;
+  firmwareUpdate: boolean;
+  printerReset: boolean;
+  rfid: boolean;
+  soundSettings: boolean;
+  printTaskSelection: boolean;
+  paperTypeSelection: boolean;
+};
+
+export type PrinterMetadata = {
+  model: string;
+  id?: readonly number[];
+  dpi: number;
+  printDirection: PrintDirection;
+  printheadPixels: number;
+  paperTypes: number[];
+  densityMin: number;
+  densityMax: number;
+  densityDefault: number;
+};
+
+export type PrinterInfo = Record<string, unknown>;
+
+export type PrinterHeartbeatData = {
+  chargeLevel?: number;
+  paperRfidSuccess?: boolean;
+  ribbonRfidSuccess?: boolean;
+  [key: string]: unknown;
+};
+
+export type PrinterRfidInfo = object;
+
+export type PrinterPacket = {
+  command: number;
+  toBytes(): Uint8Array;
+};
+
+export type PrinterEventMap = {
+  connect: { info: { deviceName?: string } };
+  disconnect: unknown;
+  printerinfofetched: { info: PrinterInfo };
+  heartbeat: { data: PrinterHeartbeatData };
+  heartbeatfailed: { failedAttempts: number };
+  printprogress: PrintProgressEvent;
+  firmwareprogress: FirmwareProgressEvent;
+  packetsent: { packet: PrinterPacket };
+  packetreceived: { packet: PrinterPacket };
+};
+
+export type PrinterEventName = keyof PrinterEventMap;
+export type PrinterEventListener<K extends PrinterEventName> = (event: PrinterEventMap[K]) => void;
+
+export interface PrinterPrintTask {
+  printInit(): Promise<void>;
+  printPage(image: EncodedImage, quantity?: number): Promise<void>;
+  waitForFinished(): Promise<void>;
+  printEnd(): Promise<unknown>;
+}
+
+export interface PrinterClient {
+  readonly family: PrinterFamily;
+  readonly connectionType: ConnectionType;
+  readonly capabilities: PrinterCapabilities;
+
+  connect(options?: { deviceId?: string }): Promise<void>;
+  disconnect(): Promise<void>;
+  isConnected(): boolean;
+
+  fetchPrinterInfo(): Promise<void>;
+  getModelMetadata(): PrinterMetadata | undefined;
+  getPrintTaskType(): PrintTaskName | undefined;
+
+  encodeCanvas(canvas: HTMLCanvasElement, pageColor: PageColorType, printDirection: PrintDirection): EncodedImage;
+  newPrintTask(name: PrintTaskName, options: Partial<PrintOptions>): PrinterPrintTask;
+  printEnd(): Promise<unknown>;
+
+  getRfidInfo(): Promise<PrinterRfidInfo>;
+  getRibbonRfidInfo(): Promise<PrinterRfidInfo>;
+  setSoundEnabled(enabled: boolean): Promise<void>;
+  reset(): Promise<void>;
+  firmwareUpgrade(data: Uint8Array, version: string): Promise<void>;
+
+  setPacketInterval(milliseconds: number): void;
+  startHeartbeat(): void;
+  stopHeartbeat(): void;
+
+  getPacketCommandName(direction: "request" | "response", command: number): string | undefined;
+
+  on<K extends PrinterEventName>(event: K, listener: PrinterEventListener<K>): this;
+  off<K extends PrinterEventName>(event: K, listener: PrinterEventListener<K>): this;
+}
+
+export type { EncodedImage, LabelType, PageColorType, PrintDirection, PrintOptions, PrintTaskName };

--- a/src/stores.ts
+++ b/src/stores.ts
@@ -12,20 +12,15 @@ import {
   type ConnectionState,
   type ConnectionType,
 } from "$/types";
+import { Utils } from "@mmote/niimbluelib";
 import {
-  NiimbotBluetoothClient,
-  NiimbotCapacitorBleClient,
-  NiimbotSerialClient,
-  RequestCommandId,
-  ResponseCommandId,
-  Utils,
-  instantiateClient,
-  type HeartbeatData,
-  type NiimbotAbstractClient,
+  instantiatePrinterClient,
+  type PrinterClient,
+  type PrinterHeartbeatData,
   type PrinterInfo,
-  type PrinterModelMeta,
-  type RfidInfo,
-} from "@mmote/niimbluelib";
+  type PrinterMetadata,
+  type PrinterRfidInfo,
+} from "$/printers";
 import { Toasts } from "$/utils/toasts";
 import { tr } from "$/utils/i18n";
 import { LocalStoragePersistence, writablePersisted } from "$/utils/persistence";
@@ -41,12 +36,12 @@ export const loadedFonts = writable<FontFace[]>([]);
 
 export const connectionState = writable<ConnectionState>("disconnected");
 export const connectedPrinterName = writable<string>("");
-export const printerClient = writable<NiimbotAbstractClient>();
-export const heartbeatData = writable<HeartbeatData>();
+export const printerClient = writable<PrinterClient>();
+export const heartbeatData = writable<PrinterHeartbeatData>();
 export const printerInfo = writable<PrinterInfo>();
-export const rfidInfo = writable<RfidInfo | undefined>();
-export const ribbonRfidInfo = writable<RfidInfo | undefined>();
-export const printerMeta = writable<PrinterModelMeta | undefined>();
+export const rfidInfo = writable<PrinterRfidInfo | undefined>();
+export const ribbonRfidInfo = writable<PrinterRfidInfo | undefined>();
+export const printerMeta = writable<PrinterMetadata | undefined>();
 export const heartbeatFails = writable<number>(0);
 export const csvData = writablePersisted<CsvParams>("csv_params", CsvParamsSchema, { data: CSV_DEFAULT });
 
@@ -70,29 +65,24 @@ export const refreshRfidInfo = () => {
     return;
   }
 
-  client.abstraction.rfidInfo().then(rfidInfo.set).catch(console.error);
+  client.getRfidInfo().then(rfidInfo.set).catch(console.error);
 
-  client.abstraction
-    .rfidInfo2()
+  client
+    .getRibbonRfidInfo()
     .then(ribbonRfidInfo.set)
     .catch(() => {});
 };
 
 export const initClient = (connectionType: ConnectionType) => {
-  printerClient.update((prevClient: NiimbotAbstractClient) => {
-    let newClient: NiimbotAbstractClient = prevClient;
+  printerClient.update((prevClient: PrinterClient) => {
+    let newClient: PrinterClient = prevClient;
 
-    if (
-      prevClient === undefined ||
-      (connectionType !== "bluetooth" && prevClient instanceof NiimbotBluetoothClient) ||
-      (connectionType !== "serial" && prevClient instanceof NiimbotSerialClient) ||
-      (connectionType !== "capacitor-ble" && prevClient instanceof NiimbotCapacitorBleClient)
-    ) {
+    if (prevClient === undefined || prevClient.connectionType !== connectionType) {
       if (prevClient !== undefined) {
         prevClient.disconnect();
       }
 
-      newClient = instantiateClient(connectionType);
+      newClient = instantiatePrinterClient(connectionType);
 
       const conf = get(appConfig);
 
@@ -101,11 +91,13 @@ export const initClient = (connectionType: ConnectionType) => {
       }
 
       newClient.on("packetsent", (e) => {
-        console.log(`>> ${Utils.bufToHex(e.packet.toBytes())} (${RequestCommandId[e.packet.command]})`);
+        const commandName = newClient.getPacketCommandName("request", e.packet.command);
+        console.log(`>> ${Utils.bufToHex(e.packet.toBytes())} (${commandName})`);
       });
 
       newClient.on("packetreceived", (e) => {
-        console.log(`<< ${Utils.bufToHex(e.packet.toBytes())} (${ResponseCommandId[e.packet.command]})`);
+        const commandName = newClient.getPacketCommandName("response", e.packet.command);
+        console.log(`<< ${Utils.bufToHex(e.packet.toBytes())} (${commandName})`);
       });
 
       newClient.on("connect", (e) => {


### PR DESCRIPTION
## Summary

* Introduce application-level interfaces for printer clients, print tasks, events, metadata, and capabilities.
* Wrap the existing NiimBlueLib clients in `NiimbotPrinterClient`.
* Remove direct access to protocol-specific client internals from stores, the printer connector, print preview, and firmware updater.
* Preserve the existing Bluetooth, serial, and Capacitor BLE behaviour.

## Motivation

This refactor makes it possible to add printer families that do not use the NIIMBOT protocol without coupling the user interface and application stores to a particular protocol implementation.

A hardware-tested Fichero D11s backend is planned as a separate follow-up contribution. This PR intentionally contains no Fichero-specific implementation or user-facing feature changes.

## Validation

* `npm run sv-check` — passed with 0 errors and 0 warnings
* `npm run build` — passed
* ESLint on every file changed by this PR — passed

The repository-wide `npm run lint` currently reports the pre-existing empty block in `src/fabric-object/custom_canvas.ts:86`. This file is unchanged by this PR.
