### PR TITLE
deps: bump @xmldom/xmldom to 0.8.15 in capacitor lock

### DIFF
--- a/osv-out.txt
+++ b/osv-out.txt
@@ -1,0 +1,2 @@
+Scanned /home/katsu/ossruns/2026-09-09-oss-sec/niimblue/standalone-apps/capacitor/package-lock.json file and found 102 packages
+No issues found

--- a/standalone-apps/capacitor/package-lock.json
+++ b/standalone-apps/capacitor/package-lock.json
@@ -381,9 +381,9 @@
       "license": "MIT"
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Updates `@xmldom/xmldom` to 0.8.15 in `standalone-apps/capacitor/package-lock.json` to address the recent xmldom advisories (GHSA-c7q8-3ch8-vqpv and related).

Evidence:
- `standalone-apps/capacitor/package-lock.json` resolved `@xmldom/xmldom@0.8.13` (pulled in by `plist@3.1.0`, range `^0.8.8`)
- osv-scanner reported the 0.8.x advisory set for 0.8.13
- updated version: `0.8.15`

Validation:
- osv-scanner reports no issues for the lockfile after the update (102 packages scanned, 0 advisories)
- `npm install --package-lock-only` keeps 0.8.15 with no other lockfile changes

Scope: lockfile update only, within the existing `^0.8.8` range.